### PR TITLE
Update package.json and import to work with latest Svelte-kit

### DIFF
--- a/SortableList.svelte
+++ b/SortableList.svelte
@@ -3,7 +3,7 @@
 	import { createEventDispatcher } from 'svelte';
 	const dispatch = createEventDispatcher();
 
-    import Sortable from 'sortablejs/modular/sortable.core.esm.js';
+    import Sortable from 'sortablejs';
 
     // every item is an object with a unique ID for identification
     export let items = [];

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Basic version of https://sortablejs.github.io/Sortable",
   "main": "SortableList.svelte",
   "svelte": "SortableList.svelte",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pal03377/svelte-sortablejs.git"


### PR DESCRIPTION
Something in the latest svelte-kit version broke the import of this package. 
The fix looks to be simple, just adding `type: module` to package.json and use the package import for sortablejs. 
Works in our codebase, but I have not touched the example since it looks to be way too outdated.